### PR TITLE
gemspec: Use Ruby to pick out files to include, drop unused "executables" directive

### DIFF
--- a/session_tracker.gemspec
+++ b/session_tracker.gemspec
@@ -9,9 +9,7 @@ Gem::Specification.new do |gem|
   gem.summary       = %q{Track active user sessions in redis}
   gem.homepage      = ""
 
-  gem.executables   = `git ls-files -- bin/*`.split("\n").map{ |f| File.basename(f) }
-  gem.files         = `git ls-files`.split("\n")
-  gem.test_files    = `git ls-files -- {test,spec,features}/*`.split("\n")
+  gem.files         = Dir["lib/**/*.rb", "README.md"]
   gem.name          = "session_tracker"
   gem.require_paths = ["lib"]
   gem.version       = SessionTracker::VERSION


### PR DESCRIPTION
Drop test_files, executables, unused. 

- test_files unused: https://stackoverflow.com/questions/18871541/what-is-the-purpose-of-test-files-configuration-in-a-gemspec
- this gem has 0 executables