### PR TITLE
Guardfile: skip old options, add new to replace them

### DIFF
--- a/Guardfile
+++ b/Guardfile
@@ -1,6 +1,7 @@
-guard 'rspec', :version => 2, :all_on_start => false,
-               :all_after_pass => false, :bundler => false,
-               :keep_failed => false do
+guard 'rspec', :all_on_start => false,
+               :all_after_pass => false,
+               :failed_mode => :keep,
+               :cmd => "bundle exec rspec" do
   watch(%r{^spec/.+_spec\.rb$})
   watch(%r{^lib/(.+)\.rb$})     { |m| "spec/#{m[1]}_spec.rb" }
 end


### PR DESCRIPTION
This PR keeps the Guardfile slightly more up-to-date, so that it avoids outputting warnings when starting it.